### PR TITLE
Add `events.mechanism` parameter to `php-fpm.ini`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ change just the ones you want to really overwrite.
       daemonize: yes
       rlimit_files: 1024
       rlimit_core: 0
+      events.mechanism: ** not set: autodetect **
       include: '/etc/php5/fpm/pool.d/*.conf'
 
 The path to the configuration file is also configured though `hwr_path_php_fpm_ini`

--- a/templates/fpm.conf.j2
+++ b/templates/fpm.conf.j2
@@ -10,6 +10,11 @@ process_control_timeout = {{ hwr_fpm_conf.process_control_timeout | default('0')
 daemonize = {{ hwr_fpm_conf.daemonize | default('yes') }}
 rlimit_files = {{ hwr_fpm_conf.rlimit_files | default('1024') }}
 rlimit_core = {{ hwr_fpm_conf.rlimit_core | default('0') }}
+
+{% if hwr_fpm_conf.events_mechanism is defined %}
+events.mechanism = {{ hwr_fpm_conf.events_mechanism }}
+{% endif %}
+
 include = {{ hwr_fpm_conf.include | default('/etc/php5/fpm/pool.d/*.conf') }}
 
 # ex: ft=jinja et sw=4 ts=4:


### PR DESCRIPTION
It should not be set unless needed so it's not on default vars, since it defaults to autodetect (which has to explicit option from what I could see)
