### PR TITLE
Manage extension configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ See [defaults/main.yml][1] for variables available to overwrite, the most useful
 | hwr_options.enable_fpm | boolean | yes | Enable creation and installation of PHP-FPM, as well as creation of FPM pools defined in another variable. |
 | hwr_fpm_pools | list | Pool with DocRoot to `/var/www/default` | List of FPM pools to be created  and enabled |
 | hwr_php_fpm_default_chdir | string | `/var/www/default` | Default document root for the default PHP FPM pool |
+| php_extensions_config | dict | empty | Set custom config for php modules, takes a `name` (required), `priority` and the `option:value` itself |
 
 ## Composer
 
@@ -129,6 +130,10 @@ file, and should be used on every pool you create.
           - section: "Date"
             option: "date.timezone"
             value: "America/Sao_Paulo"
+        php_extensions_config:
+          - name: apc
+            apc.cache_by_default: 0
+            apc.enable_cli: 1
       roles:
         - { role: augustohp.php }
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ change just the ones you want to really overwrite.
       daemonize: yes
       rlimit_files: 1024
       rlimit_core: 0
+      events.mechanism: ** not set: autodetect **
       include: '/etc/php5/fpm/pool.d/*.conf'
 
 The path to the configuration file is also configured though `hwr_path_php_fpm_ini`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -146,4 +146,6 @@ hwr_composer_bin_name: "composer"
 hwr_composer_packages:
   - "phpunit/phpunit:@stable"
 
+php_extensions_config: []
+
 # ex: filetype=ansible et ts=2 sw=2:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,19 @@
     value="{{ item.value }}"
   with_items: php_ini
 
+- name: Configure Extensions
+  template: >
+    src=extension.ini.j2
+    dest=/etc/php5/mods-available/{{ item.name }}.ini
+  with_items: php_extensions_config
+
+- name: Enable Extensions
+  file: >
+    src=/etc/php5/mods-available/{{ item.name }}.ini
+    dest=/etc/php5/conf.d/{{ item.priority | default(20) }}-{{ item.name }}.ini
+    state=link
+  with_items: php_extensions_config
+
 - include: "fpm.yml"
   when: hwr_options.enable_fpm
 

--- a/templates/extension.ini.j2
+++ b/templates/extension.ini.j2
@@ -1,0 +1,7 @@
+; {{ ansible_managed }}
+
+extension = {{ item.name }}.so
+
+{% for option, value in item.iteritems() if option not in ["name","priority"] %}
+{{ option }} = {{ value }}
+{% endfor %}

--- a/templates/fpm.conf.j2
+++ b/templates/fpm.conf.j2
@@ -10,6 +10,11 @@ process_control_timeout = {{ hwr_fpm_conf.process_control_timeout | default('0')
 daemonize = {{ hwr_fpm_conf.daemonize | default('yes') }}
 rlimit_files = {{ hwr_fpm_conf.rlimit_files | default('1024') }}
 rlimit_core = {{ hwr_fpm_conf.rlimit_core | default('0') }}
+
+{% if hwr_fpm_conf.events_mechanism is defined %}
+events.mechanism = {{ hwr_fpm_conf.events_mechanism }}
+{% endif %}
+
 include = {{ hwr_fpm_conf.include | default('/etc/php5/fpm/pool.d/*.conf') }}
 
 # ex: ft=jinja et sw=4 ts=4:


### PR DESCRIPTION
Modules might need to have custom options. This creates the file on `mods-available` and symlinks them to `conf.d`, both at `/etc/php5`.
## To dos
- [ ] Support 5.3.
- [ ] Use variables for configuration paths.
- [ ] Support `extension_name` configuration.
- [ ] Remove extensions we don't manage from `hwr_path_php_mods_enabled`.
