### PR TITLE
Support different PHP versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+*.log

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Manages PHP and FPM.
 
+| Operating System                | PHP 5.3 | PHP 5.4 | PHP 5.5 |
+|---------------------------------|---------|---------|---------|
+| Debian 6 (Squeeze)              | *Yes*   | Yes     |         |
+| Debian 7 (Wheezy)               |         | *Yes*   | Yes     |
+| Ubuntu 12.04 (Precise Pangolin) | *Yes*   | Yes     | Yes     |
+| Ubuntu 14.04 (Trusty Tahr)      |         |         | *Yes*   |
+
 ## Requirements
 
 - Ansible 1.5 or greater
@@ -13,7 +20,9 @@ See [defaults/main.yml][1] for variables available to overwrite, the most useful
 | Variable name | Value Type | Default Value | Description |
 |---------------|------------|---------------|-------------|
 | hwr_options.install_composer | boolean | yes | Installs [Composer][] globally |
+| hwr_options.php_version | float | null | Install a different PHP version on the system from the one provided by the distro. |
 | php_ini | list | Default, development values | List of `php.ini` to use on environment |
+| php_packages | list | Platform dependent | List of packages to be installed, see `vars/Debian.yml` for an example. |
 | hwr_options.enable_fpm | boolean | yes | Enable creation and installation of PHP-FPM, as well as creation of FPM pools defined in another variable. |
 | hwr_fpm_pools | list | Pool with DocRoot to `/var/www/default` | List of FPM pools to be created  and enabled |
 | hwr_php_fpm_default_chdir | string | `/var/www/default` | Default document root for the default PHP FPM pool |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby et ts=2 sw=2:
 
-# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -19,7 +18,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define "wheezy", primary: true, autostart: true do |debian|
     debian.vm.box = "chef/debian-7.4"
     debian.vm.network "private_network", ip: "192.168.27.10"
-    debian.vm.hostname = "php-role.wheezy.debian.local"
+    debian.vm.hostname = "wheezy.debian.local"
 
     debian.vm.provider :virtualbox do |vb|
       vb.name = "ansible-php-role-debian-wheezy"
@@ -30,7 +29,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define "squeeze", autostart: false do |debian|
     debian.vm.box = "chef/debian-6.0.8"
     debian.vm.network "private_network", ip: "192.168.27.11"
-    debian.vm.hostname = "php-role.squeeze.debian.local"
+    debian.vm.hostname = "squeeze.debian.local"
 
     debian.vm.provider :virtualbox do |vb|
       vb.name = "ansible-php-role-debian-squeeze"
@@ -40,8 +39,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Ubuntu 12.04 LTS
   config.vm.define "precise", autostart: false do |ubuntu|
     ubuntu.vm.box = "precise64"
-    ubuntu.vm.network "private_network", ip: "192.168.27.11"
-    ubuntu.vm.hostname = "php-role.precise.ubuntu.local"
+    ubuntu.vm.network "private_network", ip: "192.168.27.12"
+    ubuntu.vm.hostname = "precise.ubuntu.local"
 
     ubuntu.vm.provider :virtualbox do |vb|
       vb.name = "ansible-php-role-ubuntu-precise"
@@ -51,8 +50,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Ubuntu 14.04 LTS
   config.vm.define "trusty", primary: true, autostart: true do |ubuntu|
     ubuntu.vm.box = "ubuntu/trusty64"
-    ubuntu.vm.network "private_network", ip: "192.168.28.13"
-    ubuntu.vm.hostname = "php-role.trusty.ubuntu.local"
+    ubuntu.vm.network "private_network", ip: "192.168.27.13"
+    ubuntu.vm.hostname = "trusty.ubuntu.local"
 
     ubuntu.vm.provider :virtualbox do |vb|
       vb.name = "ansible-php-role-ubuntu-trusty"
@@ -62,8 +61,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # CentOS 6
   config.vm.define "centos6", autostart: false do |ubuntu|
     ubuntu.vm.box = "chef/centos-6.5"
-    ubuntu.vm.network "private_network", ip: "192.168.28.14"
-    ubuntu.vm.hostname = "php-role.6-5.centos.local"
+    ubuntu.vm.network "private_network", ip: "192.168.27.14"
+    ubuntu.vm.hostname = "6-5.centos.local"
 
     ubuntu.vm.provider :virtualbox do |vb|
       vb.name = "ansible-php-role-centos-6.5"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,57 +6,160 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder "web", "/var/www/default"
 
-  config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "test.yml"
-  end
-
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
   end
 
   # Debian 7
-  config.vm.define "wheezy", primary: true, autostart: true do |debian|
+  config.vm.define "wheezy54", primary: true, autostart: true do |debian|
     debian.vm.box = "chef/debian-7.4"
     debian.vm.network "private_network", ip: "192.168.27.10"
-    debian.vm.hostname = "wheezy.debian.local"
+    debian.vm.hostname = "wheezy54.debian.local"
 
     debian.vm.provider :virtualbox do |vb|
-      vb.name = "ansible-php-role-debian-wheezy"
+      vb.name = "ansible-php54-role-debian-wheezy"
+    end
+
+    debian.vm.provision "ansible" do |local|
+      local.playbook = "test.yml"
+      local.extra_vars = {
+        "hwr_options.install_composer" => "false",
+        "hwr_options.php_version" => "5.4"
+      }
+    end
+  end
+
+  # Debian 7
+  config.vm.define "wheezy55", primary: true, autostart: true do |debian|
+    debian.vm.box = "chef/debian-7.4"
+    debian.vm.network "private_network", ip: "192.168.27.11"
+    debian.vm.hostname = "wheezy55.debian.local"
+
+    debian.vm.provider :virtualbox do |vb|
+      vb.name = "ansible-php55-role-debian-wheezy"
+    end
+
+    debian.vm.provision "ansible" do |local|
+      local.playbook = "test.yml"
+      local.extra_vars = {
+        "hwr_options.install_composer" => "false",
+        "hwr_options.php_version" => "5.5"
+      }
     end
   end
 
   # Debian 6
-  config.vm.define "squeeze", autostart: false do |debian|
+  config.vm.define "squeeze53", autostart: false do |debian|
     debian.vm.box = "chef/debian-6.0.8"
-    debian.vm.network "private_network", ip: "192.168.27.11"
-    debian.vm.hostname = "squeeze.debian.local"
+    debian.vm.network "private_network", ip: "192.168.27.21"
+    debian.vm.hostname = "squeeze53.debian.local"
 
     debian.vm.provider :virtualbox do |vb|
-      vb.name = "ansible-php-role-debian-squeeze"
+      vb.name = "ansible-php53-role-debian-squeeze"
+    end
+
+    debian.vm.provision "ansible" do |local|
+      local.playbook = "test.yml"
+      local.extra_vars = {
+        "hwr_options.install_composer" => "false",
+        "hwr_options.php_version" => "5.3"
+      }
+    end
+  end
+
+  # Debian 6
+  config.vm.define "squeeze54", autostart: false do |debian|
+    debian.vm.box = "chef/debian-6.0.8"
+    debian.vm.network "private_network", ip: "192.168.27.22"
+    debian.vm.hostname = "squeeze54.debian.local"
+
+    debian.vm.provider :virtualbox do |vb|
+      vb.name = "ansible-php54-role-debian-squeeze"
+    end
+
+    debian.vm.provision "ansible" do |local|
+      local.playbook = "test.yml"
+      local.extra_vars = {
+        "hwr_options.install_composer" => "false",
+        "hwr_options.php_version" => "5.4"
+      }
     end
   end
 
   # Ubuntu 12.04 LTS
-  config.vm.define "precise", autostart: false do |ubuntu|
+  config.vm.define "precise53", autostart: false do |ubuntu|
     ubuntu.vm.box = "precise64"
-    ubuntu.vm.network "private_network", ip: "192.168.27.12"
-    ubuntu.vm.hostname = "precise.ubuntu.local"
+    ubuntu.vm.network "private_network", ip: "192.168.27.30"
+    ubuntu.vm.hostname = "precise53.ubuntu.local"
 
     ubuntu.vm.provider :virtualbox do |vb|
-      vb.name = "ansible-php-role-ubuntu-precise"
+      vb.name = "ansible-php53-role-ubuntu-precise"
+    end
+
+    ubuntu.vm.provision "ansible" do |local|
+      local.playbook = "test.yml"
+      local.extra_vars = {
+        "hwr_options.install_composer" => "false",
+        "hwr_options.php_version" => "5.3"
+      }
+    end
+  end
+
+  # Ubuntu 12.04 LTS
+  config.vm.define "precise54", autostart: false do |ubuntu|
+    ubuntu.vm.box = "precise64"
+    ubuntu.vm.network "private_network", ip: "192.168.27.31"
+    ubuntu.vm.hostname = "precise54.ubuntu.local"
+
+    ubuntu.vm.provider :virtualbox do |vb|
+      vb.name = "ansible-php54-role-ubuntu-precise"
+    end
+
+    ubuntu.vm.provision "ansible" do |local|
+      local.playbook = "test.yml"
+      local.extra_vars = {
+        "hwr_options.install_composer" => "false",
+        "hwr_options.php_version" => "5.4"
+      }
+    end
+  end
+
+  # Ubuntu 12.04 LTS
+  config.vm.define "precise55", autostart: false do |ubuntu|
+    ubuntu.vm.box = "precise64"
+    ubuntu.vm.network "private_network", ip: "192.168.27.32"
+    ubuntu.vm.hostname = "precise55.ubuntu.local"
+
+    ubuntu.vm.provider :virtualbox do |vb|
+      vb.name = "ansible-php55-role-ubuntu-precise"
+    end
+
+    ubuntu.vm.provision "ansible" do |local|
+      local.playbook = "test.yml"
+      local.extra_vars = {
+        "hwr_options.install_composer" => "false",
+        "hwr_options.php_version" => "5.5"
+      }
     end
   end
 
   # Ubuntu 14.04 LTS
-  config.vm.define "trusty", primary: true, autostart: true do |ubuntu|
+  config.vm.define "trusty55", primary: true, autostart: true do |ubuntu|
     ubuntu.vm.box = "ubuntu/trusty64"
-    ubuntu.vm.network "private_network", ip: "192.168.27.13"
-    ubuntu.vm.hostname = "trusty.ubuntu.local"
+    ubuntu.vm.network "private_network", ip: "192.168.27.40"
+    ubuntu.vm.hostname = "trusty55.ubuntu.local"
 
     ubuntu.vm.provider :virtualbox do |vb|
-      vb.name = "ansible-php-role-ubuntu-trusty"
+      vb.name = "ansible-php55-role-ubuntu-trusty"
     end
-  end
+
+    ubuntu.vm.provision "ansible" do |local|
+      local.playbook = "test.yml"
+      local.extra_vars = {
+        "hwr_options.install_composer" => "false",
+        "hwr_options.php_version" => "5.5"
+      }
+    end  end
 
   # CentOS 6
   config.vm.define "centos6", autostart: false do |ubuntu|
@@ -68,5 +171,4 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.name = "ansible-php-role-centos-6.5"
     end
   end
-
 end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,6 @@ hwr_options:
   install_composer: yes
 
 php_ini:
-  # Use this in your playbooks to define your desired configuration
   - section: "PHP"
     option: "display_errors"
     value: "On"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,16 +1,14 @@
 ---
-- name: Debian | Include role variables
+- name: Debian | Include role variables.
   include_vars: "Debian.yml"
 
-- name: Dabian (squeeze) | Include role variables
-  include_vars: "Debian-squeeze.yml"
-  when: ansible_lsb.codename == 'squeeze'
+- name: Debian | Define current distribution and required PHP version.
+  set_fact: hwr_path_debian_version_variables="Debian_{{ ansible_lsb.codename }}_php{{ hwr_options.php_version }}.yml"
+  when: hwr_options.php_version is defined
 
-- name: Debian (squeeze) | Enable LTS
-  apt_repository: >
-    repo='deb http://http.debian.net/debian/ squeeze-lts main contrib non-free'
-    state=present
-  when: ansible_lsb.codename == 'squeeze'
+- name: Dabian | Include LSB and PHP version variables
+  include_vars: "{{ hwr_path_debian_version_variables }}"
+  when: hwr_path_debian_version_variables is defined
 
 - name: Debian | Compile PHP packages to install
   set_fact: php_packages="{{ hwr_default_php_packages + hwr_php_fpm_packages | list }}"
@@ -22,7 +20,6 @@
     state="{{ item.state }}"
   with_items: hwr_apt_keys
   when:
-    - ansible_os_family == "Debian"
     - hwr_apt_keys is defined
 
 - name: Debian | Enable APT repositories
@@ -32,7 +29,6 @@
     update_cache=yes
   with_items: hwr_apt_repositories
   when:
-    - ansible_os_family == "Debian"
     - hwr_apt_repositories is defined
 
 - name: Debian | Installation
@@ -43,6 +39,5 @@
     update_cache=yes
     cache_valid_time=300
   with_items: php_packages
-  when: ansible_os_family == "Debian"
 
 # ex: ft=ansible et sw=2 ts=2:

--- a/test.yml
+++ b/test.yml
@@ -1,5 +1,5 @@
 ---
-- name: All available roles _o7
+- name: Test | Install and configure PHP.
   hosts: all
   sudo: yes
   vars_files:

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Execute local tests
+
+set -o pipefail
+
+VAGRANT=`which vagrant`
+TAIL_LINES=15
+
+[[ -z "$VAGRANT" ]] && { echo "vagrant not installed."; exit 1; }
+
+function indent
+{
+    sed "s/^/    /"
+}
+
+function testMachineProvisioning
+{
+    machineName=$1
+    logFile=$2
+    [[ -z "$machineName" ]] && { echo "Missing machine name on machine provisioning."; return 1; }
+    [[ -z "$logFile" ]] && { echo "Missing log file on machine provisioning."; return 1; }
+
+    echo ">>> Execute test assertion on VM."
+    $VAGRANT ssh $machineName --command "php -v" &> $logFile || { return 4; }
+    $VAGRANT ssh $machineName --command "sudo php5-fpm -v" &> $logFile || { return 4; }
+    return 0;
+}
+
+function setUp
+{
+    machineName=$1
+    logFile=$2
+    [[ -z "$machineName" ]] && { echo "Missing machine name on set up."; return 1; }
+    [[ -z "$logFile" ]] && { echo "Missing log file on machine set up." return 1; }
+
+    echo ">>> Create VM.";
+    $VAGRANT up --no-provision  $machineName 1>> $logFile 2>> $logFile || { return 2; }
+    echo ">>> Execute provision on created VM."
+    $VAGRANT provision $machineName 1>> $logFile 2>> $logFile || { return 3; }
+
+    return 0;
+}
+
+function tearDown
+{
+    machineName=$1
+    logFile=$2
+    [[ -z "$machineName" ]] && { echo "Missing machine name on tear down."; return 1; }
+    [[ -z "$logFile" ]] && { echo "Missing log file on tear down."; return 1; }
+
+    echo ">>> Tear down."
+    $VAGRANT halt $machineName 1>> $logFile 2>> $logFile
+}
+
+function outputTestResult
+{
+    result=$1
+    logFile=$2
+    [[ -z "$result" ]] && { echo "Missing result on output control."; return 1; }
+    [[ -z "$logFile" ]] && { echo "Missing log file on output control."; return 1; }
+
+    if [ "$result" -eq "0" ]; then
+        echo ">>> Test successful."
+    else
+        echo "!!! Test failed."
+        tail -n $TAIL_LINES $logFile | indent
+        finalLogFile="test_${machineName}.log"
+        mv $logFile $finalLogFile
+        echo "Full log available on: $finalLogFile"
+    fi
+
+    return $result;
+}
+
+function runTest
+{
+    machineName=$1
+    testName=$2
+    debugFile=/tmp/augustohp.ansible-role-php.log
+
+    [[ -z "$machineName" ]] && { echo "Missing machine name on test execution."; return 1; }
+    [[ -z "$testName" ]] && { echo "Missing test name on test execution."; return 1; }
+    echo ">>> $testName ... "
+    echo "" > $debugFile
+    setUp $machineName $debugFile | indent && testMachineProvisioning $machineName $debugFile | indent
+    testResult=$?
+    tearDown $machineName $debugFile | indent
+    outputTestResult $testResult $debugFile | indent
+}
+
+echo "Ansible PHP Role: Test Suite"
+echo ""
+runTest squeeze53 "PHP 5.3: Debian 6 (Squeeze)"
+runTest squeeze54 "PHP 5.4: Debian 6 (Squeeze)"
+runTest wheezy54 "PHP 5.4: Debian 7 (Wheezy)"
+runTest wheezy55 "PHP 5.5: Debian 7 (Wheezy)"
+runTest precise53 "PHP 5.3: Ubuntu 12.04 LTS (Precise Pangolin)"
+runTest precise54 "PHP 5.4: Ubuntu 12.04 LTS (Precise Pangolin)"
+runTest precise55 "PHP 5.5: Ubuntu 12.04 LTS (Precise Pangolin)"
+runTest trusty55 "PHP 5.5: Ubuntu 14.04 LTS (Trusty Tahr)"

--- a/vars/Debian_precise_php5.4.yml
+++ b/vars/Debian_precise_php5.4.yml
@@ -1,0 +1,9 @@
+# Ubuntu 12.04 LTS (Precise)
+# PHP 5.4
+---
+hwr_apt_keys: []
+hwr_apt_repositories:
+  - repo: "ppa:ondrej/php5-oldstable"
+    state: present
+
+# ex: filetype=ansible et ts=2 sw=2:

--- a/vars/Debian_precise_php5.5.yml
+++ b/vars/Debian_precise_php5.5.yml
@@ -1,0 +1,9 @@
+# Ubuntu 12.04 LTS (Precise)
+# PHP 5.5
+---
+hwr_apt_keys: []
+hwr_apt_repositories:
+  - repo: "ppa:ondrej/php5"
+    state: present
+
+# ex: filetype=ansible et ts=2 sw=2:

--- a/vars/Debian_squeeze_php5.3.yml
+++ b/vars/Debian_squeeze_php5.3.yml
@@ -1,0 +1,14 @@
+# Debian Squeeze 6
+# PHP 5.3 configuration
+---
+hwr_apt_keys:
+  - url: "http://www.dotdeb.org/dotdeb.gpg"
+    state: present
+
+hwr_apt_repositories:
+  - repo: 'deb http://packages.dotdeb.org squeeze all'
+    state: present
+  - repo: 'deb-src http://packages.dotdeb.org squeeze all'
+    state: present
+
+# ex: filetype=ansible et ts=2 sw=2:

--- a/vars/Debian_squeeze_php5.4.yml
+++ b/vars/Debian_squeeze_php5.4.yml
@@ -1,0 +1,12 @@
+---
+hwr_apt_keys:
+  - url: "http://www.dotdeb.org/dotdeb.gpg"
+    state: present
+
+hwr_apt_repositories:
+  - repo: 'deb http://packages.dotdeb.org squeeze-php54 all'
+    state: present
+  - repo: 'deb-src http://packages.dotdeb.org squeeze-php54 all'
+    state: present
+
+# ex: filetype=ansible et ts=2 sw=2:

--- a/vars/Debian_trusty_php5.5.yml
+++ b/vars/Debian_trusty_php5.5.yml
@@ -1,0 +1,5 @@
+# Ubuntu trusty 14.04 (LTS)
+# PHP 5.5 configuration
+---
+hwr_apt_keys: []
+hwr_apt_repositories: []

--- a/vars/Debian_wheezy_php5.4.yml
+++ b/vars/Debian_wheezy_php5.4.yml
@@ -1,0 +1,14 @@
+# Debian 7 (Wheezy)
+# PHP 5.4
+---
+hwr_apt_keys:
+  - url: "http://www.dotdeb.org/dotdeb.gpg"
+    state: present
+
+hwr_apt_repositories:
+  - repo: 'deb http://packages.dotdeb.org wheezy all'
+    state: present
+  - repo: 'deb-src http://packages.dotdeb.org wheezy all'
+    state: present
+
+# ex: filetype=ansible et ts=2 sw=2:

--- a/vars/Debian_wheezy_php5.5.yml
+++ b/vars/Debian_wheezy_php5.5.yml
@@ -1,0 +1,15 @@
+# Debian 7 (Wheezy)
+# PHP 5.5
+---
+hwr_apt_keys:
+  - url: "http://www.dotdeb.org/dotdeb.gpg"
+    state: present
+
+hwr_apt_repositories:
+  - repo: 'deb http://packages.dotdeb.org wheezy-php55 all'
+    state: present
+  - repo: 'deb-src http://packages.dotdeb.org wheezy-php55 all'
+    state: present
+
+
+# ex: filetype=ansible et ts=2 sw=2:


### PR DESCRIPTION
Allows definition of different PHP versions to be installed instead of the one provided by the OS, not all versions are supported by all OSes as shown on `README`.

Related to #15.
