### PR TITLE
Make Composer task idempotent

### DIFF
--- a/tasks/composer.yml
+++ b/tasks/composer.yml
@@ -28,6 +28,8 @@
   command: "{{ hwr_composer }} global require {{ item }}"
   with_items: hwr_composer_packages
   when: hwr_composer_packages is defined
+  register: composer_result
+  changed_when: "composer_result.rc != 0"
 
 - name: Composer | Crontab for self-update.
   cron: >


### PR DESCRIPTION
This is still a temporary fix, since Composer probably needs its own module that properly checks for things. But at least it will not display the task as `changed` when it actually didn't change anything :). 

This fixes #17 
