### PR TITLE
Make Composer task idempotent.

### DIFF
--- a/tasks/composer.yml
+++ b/tasks/composer.yml
@@ -28,6 +28,8 @@
   command: "{{ hwr_composer }} global require {{ item }}"
   with_items: hwr_composer_packages
   when: hwr_composer_packages is defined
+  register: composer_result
+  changed_when: '"Nothing to install or update" not in composer_result.stdout_lines'
 
 - name: Composer | Crontab for self-update.
   cron: >


### PR DESCRIPTION
Composer installation task now properly defines the change status if
nothing was installed or updated by cheking the command output given by
the `composer install` command itself.

Fixes #17, #21 and #22 issues.
