### PR TITLE
Add additional INI configuration management

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See [defaults/main.yml][1] for variables available to overwrite, the most useful
 |---------------|------------|---------------|-------------|
 | hwr_options.install_composer | boolean | yes | Installs [Composer][] globally |
 | hwr_options.php_version | float | null | Install a different PHP version on the system from the one provided by the distro. |
+| hwr_options.remove_unmanaged_extension_configuration | boolean | no | Remove unmanaged extension configuration files. |
 | php_ini | list | Default, development values | List of `php.ini` to use on environment |
 | php_packages | list | Platform dependent | List of packages to be installed, see `vars/Debian.yml` for an example. |
 | php_pecl_packages | list | `[]` | List of [pecl][] packages to install. |
@@ -28,7 +29,7 @@ See [defaults/main.yml][1] for variables available to overwrite, the most useful
 | hwr_options.enable_fpm | boolean | yes | Enable creation and installation of PHP-FPM, as well as creation of FPM pools defined in another variable. |
 | hwr_fpm_pools | list | Pool with DocRoot to `/var/www/default` | List of FPM pools to be created  and enabled |
 | hwr_php_fpm_default_chdir | string | `/var/www/default` | Default document root for the default PHP FPM pool |
-| php_extensions_config | dict | empty | Set custom config for php modules, takes a `name` (required), `priority` and the `option:value` itself |
+| php_extensions_config | dict | empty | Set custom config for php modules, overrides all other module configuration. |
 
 ### PECL packages
 
@@ -135,6 +136,38 @@ default values are show below:
 Variables `hwr_http_user` and `hwr_http_user_group` are defined on the OS variable
 file, and should be used on every pool you create.
 
+### Module configuration
+
+| Variable              | Required | Value Type | Parent Variable       | Description |
+|-----------------------|----------|------------|-----------------------|-------------|
+| php_extensions_config | No       | list<dict> |                       | List of extension configurations. |
+| file_name             | Yes      | string     | php_extensions_config | Name of the configuration file (ini) to be used. |
+| extension_path        | Yes      | string     | php_extensions_config | Path of the extension to be loaded, used by `extension` configuration option. |
+| <option name>         | No       | string     | php_extensions_config | Will be added into ini. |
+
+Module configuration can be separated from `php.ini`, which is often the default
+for some OSes (Debian family). You can use `php_extensions_config` variable to
+manage these configurations.
+
+These variable should contain a *lis* of *dicts*, if we want to manage [APC][]
+configuration for example:
+
+```yml
+# roles/my-php-role/group_vars/all.yml
+
+php_extensions_config:
+    - file_name: apc.ini
+      extension_path: apc.so
+      apc.enable: 1
+      apc.cache_by_default: 0
+      apc.enable_cli: 1
+      apc.write_lock: 0
+```
+
+By default, unmanaged extension configuration (and loading) will not be modified,
+you can use `hwr_options.remove_unmanaged_extension_configuration` to enable removing
+unmanaged extension configuration.
+
 ## Example playbook
 
     ---
@@ -158,7 +191,8 @@ file, and should be used on every pool you create.
             - mongo
             - timezonedb
         php_extensions_config:
-          - name: apc
+          - filename: apc.ini
+            extension_path: apc.so
             apc.cache_by_default: 0
             apc.enable_cli: 1
       roles:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ See [defaults/main.yml][1] for variables available to overwrite, the most useful
 | hwr_options.enable_fpm | boolean | yes | Enable creation and installation of PHP-FPM, as well as creation of FPM pools defined in another variable. |
 | hwr_fpm_pools | list | Pool with DocRoot to `/var/www/default` | List of FPM pools to be created  and enabled |
 | hwr_php_fpm_default_chdir | string | `/var/www/default` | Default document root for the default PHP FPM pool |
+| php_extensions_config | dict | empty | Set custom config for php modules, takes a `name` (required), `priority` and the `option:value` itself |
 
 ### PECL packages
 
@@ -156,6 +157,10 @@ file, and should be used on every pool you create.
         php_pecl_packages:
             - mongo
             - timezonedb
+        php_extensions_config:
+          - name: apc
+            apc.cache_by_default: 0
+            apc.enable_cli: 1
       roles:
         - { role: augustohp.php }
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -145,4 +145,6 @@ hwr_composer_bin_name: "composer"
 hwr_composer_packages:
   - "phpunit/phpunit:@stable"
 
+php_extensions_config: []
+
 # ex: filetype=ansible et ts=2 sw=2:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 hwr_options:
   enable_fpm: yes
   install_composer: yes
+  remove_unmanaged_extension_configuration: no
 
 php_ini:
   - section: "PHP"
@@ -145,6 +146,10 @@ hwr_composer_bin_name: "composer"
 hwr_composer_packages:
   - "phpunit/phpunit:@stable"
 
-php_extensions_config: []
+php_extensions_config:
+  - file_name: apc.ini
+    extension_path: apc.so
+    apc.enable: 1
+    apc.enable_cli: 1
 
 # ex: filetype=ansible et ts=2 sw=2:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,19 @@
     value="{{ item.value }}"
   with_items: php_ini
 
+- name: Configure Extensions
+  template: >
+    src=extension.ini.j2
+    dest=/etc/php5/mods-available/{{ item.name }}.ini
+  with_items: php_extensions_config
+
+- name: Enable Extensions
+  file: >
+    src=/etc/php5/mods-available/{{ item.name }}.ini
+    dest=/etc/php5/conf.d/{{ item.priority | default(20) }}-{{ item.name }}.ini
+    state=link
+  with_items: php_extensions_config
+
 - include: "fpm.yml"
   when: hwr_options.enable_fpm
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,29 +6,16 @@
 - include: "Debian.yml"
   when: ansible_os_family == "Debian"
 
-- name: Compile desired php.ini
+- name: Compile desired php.ini.
   set_fact: php_ini="{{ hwr_config_php_ini + php_ini }}"
 
-- name: CLI's php.ini configuration
+- name: CLI's php.ini configuration.
   ini_file: >
     dest="{{ hwr_path_php_ini_cli }}"
     section="{{ item.section }}"
     option="{{ item.option }}"
     value="{{ item.value }}"
   with_items: php_ini
-
-- name: Configure Extensions
-  template: >
-    src=extension.ini.j2
-    dest=/etc/php5/mods-available/{{ item.name }}.ini
-  with_items: php_extensions_config
-
-- name: Enable Extensions
-  file: >
-    src=/etc/php5/mods-available/{{ item.name }}.ini
-    dest=/etc/php5/conf.d/{{ item.priority | default(20) }}-{{ item.name }}.ini
-    state=link
-  with_items: php_extensions_config
 
 - include: "fpm.yml"
   when: hwr_options.enable_fpm

--- a/tasks/pecl.yml
+++ b/tasks/pecl.yml
@@ -3,7 +3,7 @@
 # Installs pecl packages
 ---
 
-- name: PEAR | Ensure package is installed (Debian).
+- name: PECL | Ensure package is installed (Debian).
   apt: >
     pkg="{{ item }}"
     state=present
@@ -14,4 +14,21 @@
   shell: "printf \"\\n\" | pecl install --force {{ item }}"
   with_items: php_pecl_packages
 
+- name: PECL | Apply/Enable extension configurations.
+  template: >
+    src=extension.ini.j2
+    dest="{{ hwr_path_php_mods_enabled }}/{{ item.file_name }}"
+  with_items: php_extensions_config
+
+- name: PECL | Search for unmanaged extension configuration.
+  shell: 'grep -L "^; Ansible managed:" {{ hwr_path_php_mods_enabled }}/*.ini'
+  register: _unmanaged_conf_files
+  when: hwr_options.remove_unmanaged_extension_configuration
+
+- name: PECL | Remove unmanaged configuration files.
+  file: >
+    path="{{ item }}"
+    state="absent"
+  with_items: _unmanaged_conf_files.stdout_lines
+  when: hwr_options.remove_unmanaged_extension_configuration
 # ex: ft=ansible et sw=2 ts=2:

--- a/templates/extension.ini.j2
+++ b/templates/extension.ini.j2
@@ -1,0 +1,7 @@
+; {{ ansible_managed }}
+
+extension = {{ item.name }}.so
+
+{% for option, value in item.iteritems() if option not in ["name","priority"] %}
+{{ option }} = {{ value }}
+{% endfor %}

--- a/templates/extension.ini.j2
+++ b/templates/extension.ini.j2
@@ -1,7 +1,7 @@
 ; {{ ansible_managed }}
 
-extension = {{ item.name }}.so
+extension = {{ item.extension_path }}
 
-{% for option, value in item.iteritems() if option not in ["name","priority"] %}
+{% for option, value in item.iteritems() if option not in ["file_name", "extension_path"] %}
 {{ option }} = {{ value }}
 {% endfor %}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -31,5 +31,6 @@ hwr_path_php_fpm_conf: /etc/php5/fpm/php-fpm.conf
 hwr_path_php_fpm_pools: /etc/php5/fpm/pool.d
 hwr_http_user: www-data
 hwr_http_user_group: www-data
+hwr_path_php_mods_enabled: /etc/php5/conf.d
 
 # ex: filetype=ansible et sw=2 ts=2:


### PR DESCRIPTION
Manages [configuration of additional INI files](http://php.net/php_ini_scanned_files) which is used by [Debian](http://debian.org) to load additional extensions.
