### PR TITLE
Enable configuration of multiple php.ini.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See [defaults/main.yml][1] for variables available to overwrite, the most useful
 | hwr_options.php_version | float | null | Install a different PHP version on the system from the one provided by the distro. |
 | hwr_options.remove_unmanaged_extension_configuration | boolean | no | Remove unmanaged extension configuration files. |
 | php_ini | list | Default, development values | List of `php.ini` to use on environment |
+| php_ini_files | list | `[]` | List of `php.ini` files to apply changes to. (CLI and FPM not needed to appear in this list) |
 | php_packages | list | Platform dependent | List of packages to be installed, see `vars/Debian.yml` for an example. |
 | php_pecl_packages | list | `[]` | List of [pecl][] packages to install. |
 | php_packages_extra | list | `[]` | List of OS packages to install (Utility configuration). |
@@ -135,6 +136,37 @@ default values are show below:
 
 Variables `hwr_http_user` and `hwr_http_user_group` are defined on the OS variable
 file, and should be used on every pool you create.
+
+### `php.ini` configuration
+
+You can manage `php.ini` configurations using `php_ini` variable. If you want to display
+errors, for example:
+
+```yml
+# roles/my-php-role/group_vars/all.yml
+
+php_ini:
+    - section: "PHP"
+      option: "display_errors"
+      value: "On"
+    - section: "PHP"
+      option: "error_reporting"
+      value: "-1"
+```
+
+Configurations will always be applied to the CLI `php.ini` file. If `php-fpm` is
+enabled than its configuration will be changed too.
+
+When you use a web server, you probably want to apply changes to another `php.ini`
+files, this can be done with `php_ini_files` directive. It would look like this:
+
+```yml
+# roles/my-php-role/group_vars/all.yml
+
+php_ini_files:
+    - /etc/php5/apache2/php.ini
+    - /etc/php5/nginx/php.ini
+```
 
 ### Module configuration
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -152,4 +152,6 @@ php_extensions_config:
     apc.enable: 1
     apc.enable_cli: 1
 
+php_ini_files: []
+
 # ex: filetype=ansible et ts=2 sw=2:

--- a/tasks/fpm.yml
+++ b/tasks/fpm.yml
@@ -3,14 +3,6 @@
 # Manage FPM pools and configuration.
 ---
 
-- name: FPM | php.ini configuration.
-  ini_file: >
-    dest="{{ hwr_path_php_ini_fpm }}"
-    section="{{ item.section }}"
-    option="{{ item.option }}"
-    value="{{ item.value }}"
-  with_items: php_ini
-
 - name: FPM | php-fpm.conf configuration.
   template: >
     src="fpm.conf.j2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,17 +6,6 @@
 - include: "Debian.yml"
   when: ansible_os_family == "Debian"
 
-- name: Compile desired php.ini.
-  set_fact: php_ini="{{ hwr_config_php_ini + php_ini }}"
-
-- name: CLI's php.ini configuration.
-  ini_file: >
-    dest="{{ hwr_path_php_ini_cli }}"
-    section="{{ item.section }}"
-    option="{{ item.option }}"
-    value="{{ item.value }}"
-  with_items: php_ini
-
 - include: "fpm.yml"
   when: hwr_options.enable_fpm
 
@@ -25,5 +14,7 @@
 
 - include: "pecl.yml"
   when: php_pecl_packages is defined
+
+- include: "php-ini.yml"
 
 # ex: ft=ansible et sw=2 ts=2:

--- a/tasks/php-ini.yml
+++ b/tasks/php-ini.yml
@@ -1,0 +1,36 @@
+# tasks/php-ini.fpm
+#
+# Defines PHP.ini configuration, and use it fir
+# different SAPIs.
+---
+
+- name: php.ini | Compile desired configuration.
+  set_fact:
+    _php_ini_configurations: "{{ hwr_config_php_ini + php_ini }}"
+
+- name: php.ini | Apply configuration.
+  ini_file: >
+    dest="{{ hwr_path_php_ini_cli }}"
+    section="{{ item.section }}"
+    option="{{ item.option }}"
+    value="{{ item.value }}"
+  with_items: _php_ini_configurations|list
+
+- name: php.ini | Link FPM's `php.ini` file to the main one.
+  file: >
+    src={{ hwr_path_php_ini_cli }}
+    dest={{ hwr_path_php_ini_fpm }}
+    state=link
+    force=yes
+  when: hwr_options.enable_fpm
+
+- name: php.ini | Link additional `php.ini` files to the main one.
+  file: >
+    src={{ hwr_path_php_ini_cli }}
+    dest={{ item }}
+    state="link"
+  with_items: php_ini_files
+  when:
+    - php_ini_files|count > 0
+
+# ex: ft=ansible et sw=2 ts=2:


### PR DESCRIPTION
When using an HTTP server, different PHP files may be present and we
also want to apply out changes to those files as well.

This commit adds a `php_ini_files` variable which lists files that
symlink to the CLI `php.ini` file. PHP FPM configuration is already
managed bu the role.

Fixes #10.
