### PR TITLE
Defaulting `php_packages_extra` to empty list

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Ensure php_packages_extra is defined.
-  set_fact: php_packages_extra=[]
+  set_fact:
+    php_packages_extra: []
   when: php_packages_extra is not defined
 
 - include: "Debian.yml"


### PR DESCRIPTION
When `php_packages_extra` is left undefined, the [task intended to define it as an empty list](https://github.com/augustohp/ansible-role-php/blob/1a12f0e6d196dea0608d5f9a2f04d68ef2068ab3/tasks/main.yml#L3) can cause a strange bug:

```
TASK: [php | Debian | Installation] ******************************************* 
failed: [default] => (item=php5,php5-cli,php5-common,php5-curl,php5-gd,php5-intl,php5-mcrypt,php5-mysqlnd,php5-sqlite,php5-xsl,php5-dbg,php5-dev,php5-xdebug,curl,php5-fpm,[,]) => {"failed": true, "item": "php5,php5-cli,php5-common,php5-curl,php5-gd,php5-intl,php5-mcrypt,php5-mysqlnd,php5-sqlite,php5-xsl,php5-dbg,php5-dev,php5-xdebug,curl,php5-fpm,[,]"}
msg: No package(s) matching '[' available
```

(This is with Ansible 1.6.7, Vagrant 1.6.5, and a Precise64 box.)

It looks to be a [known bug](https://groups.google.com/forum/#!topic/ansible-project/5IZZImuYafs) with the short form of `set_fact`.
